### PR TITLE
Enforce column type when removing column

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,34 @@ class BackportPublishedDefaultOnPosts < ActiveRecord::Migration
 end
 ```
 
+### Removing a column without specifying the column type
+
+#### Bad
+
+Attempting to rollback this migration will cause Rails to raise an error.
+
+```ruby
+class RemovePublishedFromPosts < ActiveRecord::Migration
+  def change
+    remove_column :posts, :published
+  end
+end
+```
+
+#### Good
+
+Instead, let's include the column's type as the third argument of the `remove_column` method.
+
+This allows Rails to rollback the migration without errors.
+
+```ruby
+class RemovePublishedFromPosts < ActiveRecord::Migration
+  def change
+    remove_column :posts, :published, :boolean
+  end
+end
+```
+
 ### Adding an index concurrently
 
 #### Bad

--- a/lib/zero_downtime_migrations.rb
+++ b/lib/zero_downtime_migrations.rb
@@ -11,6 +11,7 @@ require_relative "zero_downtime_migrations/validation/add_index"
 require_relative "zero_downtime_migrations/validation/ddl_migration"
 require_relative "zero_downtime_migrations/validation/find_each"
 require_relative "zero_downtime_migrations/validation/mixed_migration"
+require_relative "zero_downtime_migrations/validation/remove_column"
 
 ActiveRecord::Migration.send(:prepend, ZeroDowntimeMigrations::Migration)
 ActiveRecord::Schema.send(:prepend, ZeroDowntimeMigrations::Migration)

--- a/lib/zero_downtime_migrations/migration.rb
+++ b/lib/zero_downtime_migrations/migration.rb
@@ -103,8 +103,8 @@ module ZeroDowntimeMigrations
       Migration.safe = safe
     end
 
-    def validate(type, *args)
-      Validation.validate!(type, *args)
+    def validate(method, *args)
+      Validation.validate!(method, *args)
     rescue UndefinedValidationError
       nil
     end

--- a/lib/zero_downtime_migrations/validation.rb
+++ b/lib/zero_downtime_migrations/validation.rb
@@ -1,10 +1,10 @@
 module ZeroDowntimeMigrations
   class Validation
-    def self.validate!(type, *args)
+    def self.validate!(method, *args)
       return unless Migration.migrating? && Migration.unsafe?
 
       begin
-        validator = type.to_s.classify
+        validator = method.to_s.classify
         const_get(validator).new(Migration.current, *args).validate!
       rescue NameError
         raise UndefinedValidationError.new(validator)

--- a/lib/zero_downtime_migrations/validation.rb
+++ b/lib/zero_downtime_migrations/validation.rb
@@ -33,6 +33,18 @@ module ZeroDowntimeMigrations
       args.last.is_a?(Hash) ? args.last : {}
     end
 
+    def type
+      args.last.is_a?(Hash) ? args[-2] : args[-1]
+    end
+
+    def valid_type?
+      # list of valid (database-agnostic) migration types:
+      # https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-add_column
+      #
+      valid_types = %i(primary_key string text integer bigint float decimal numeric datetime time date binary boolean)
+      valid_types.include?(type)
+    end
+
     def validate!
       raise NotImplementedError
     end

--- a/lib/zero_downtime_migrations/validation/remove_column.rb
+++ b/lib/zero_downtime_migrations/validation/remove_column.rb
@@ -1,0 +1,74 @@
+module ZeroDowntimeMigrations
+  class Validation
+    class RemoveColumn < Validation
+      def validate!
+        return if valid_type?
+        error!(message)
+      end
+
+      private
+
+      def message
+        <<-MESSAGE.strip_heredoc
+          Removing a column is not reversible unless you provide a type
+          on the column.
+          
+          In order to make this migration reversible, add a third argument 
+          to the remove_column method which corresponds to the type of 
+          the column.
+
+          For example, if this column is a boolean, then let's add :boolean
+          as remove_column's third argument.
+
+            class Remove#{column_title}From#{table_title} < ActiveRecord::Migration
+              def change
+                remove_column :#{table}, :#{column}, :boolean
+              end
+            end
+
+          This gem only checks for database-agnostic types listed in the 
+          Rails documentation: 
+          https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-add_column
+
+          If you are using a database-specific type in your columns 
+          (such as "polygon" in MySQL or "jsonb" in PostgreSQL), then this
+          migration will still be reversible provided that you include the
+          correct type as the third argument of remove_column.
+
+          If you're 100% positive that this migration is already safe, then wrap the
+          call to `remove_column` in a `safety_assured` block.
+
+            class Remove#{column_title}From#{table_title} < ActiveRecord::Migration
+              def change
+                safety_assured { add_column :#{table}, :#{column}, :#{column_type || default_type} }
+              end
+            end
+        MESSAGE
+      end
+
+      def column
+        args[1]
+      end
+
+      def column_title
+        column.to_s.camelize
+      end
+
+      def column_type
+        args[2]
+      end
+
+      def default_type
+        :boolean
+      end
+
+      def table
+        args[0]
+      end
+
+      def table_title
+        table.to_s.camelize
+      end
+    end
+  end
+end

--- a/spec/zero_downtime_migrations/validation/remove_column_spec.rb
+++ b/spec/zero_downtime_migrations/validation/remove_column_spec.rb
@@ -1,0 +1,45 @@
+RSpec.describe ZeroDowntimeMigrations::Validation::RemoveColumn do
+  let(:error) { ZeroDowntimeMigrations::UnsafeMigrationError }
+
+  context "without a type" do
+    let(:migration) do
+      Class.new(ActiveRecord::Migration[5.0]) do
+        def change
+          remove_column :users, :active
+        end
+      end
+    end
+
+    it "raises an unsafe migration error" do
+      expect { migration.migrate(:up) }.to raise_error(error)
+    end
+  end
+
+  context "with an unsupported or non-agnostic type" do
+    let(:migration) do
+      Class.new(ActiveRecord::Migration[5.0]) do
+        def change
+          remove_column :users, :active, :jsonb
+        end
+      end
+    end
+
+    it "raises an unsafe migration error" do
+      expect { migration.migrate(:up) }.to raise_error(error)
+    end
+  end
+
+  context "with a valid type" do
+    let(:migration) do
+      Class.new(ActiveRecord::Migration[5.0]) do
+        def change
+          remove_column :users, :active, :boolean
+        end
+      end
+    end
+
+    it "does not raise an unsafe migration error" do
+      expect { migration.migrate(:up) }.not_to raise_error(error)
+    end
+  end
+end


### PR DESCRIPTION
🚨 NOTE: this is based on my PR to the original fork -- https://github.com/LendingHome/zero_downtime_migrations/pull/32 -- but that gem appears to not be actively maintained. Figured we can add Envoy-specific migration styles to this fork in the meantime. 🚨 

Adds a new validation that warns when a `remove_column` migration is run without providing a column type. 

Bad (rails raises [this error](https://github.com/rails/rails/blob/bdd8d5898710e727c55b514804a221b6eddbda41/activerecord/lib/active_record/migration/command_recorder.rb#L164-L167) when attempting a rollback): 

```ruby
class RemovePublishedFromPosts < ActiveRecord::Migration
  def change
    remove_column :posts, :published
  end
end
```

Good: 

```ruby
class RemovePublishedFromPosts < ActiveRecord::Migration
  def change
    remove_column :posts, :published, :boolean
  end
end
```

Note that this branch only checks for database-agnostic types listed in the [Rails API docs](https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-add_column). I'm open to also including types specific to Postgres, MySQL, and SQLite, so that users of the most common DBs don't get extraneous errors from this gem. The guides have an [official page for Postgres types](https://edgeguides.rubyonrails.org/active_record_postgresql.html) -- I don't see a corresponding one for MySQL or SQLite, but can try to hunt down an official types list for each of those if you think that's a reasonable next step.